### PR TITLE
fix(gamepad_input): fixed movement, camera movement and fire

### DIFF
--- a/src/combat/player.rs
+++ b/src/combat/player.rs
@@ -97,13 +97,15 @@ impl Default for InputMap {
             ]),
             mouse_rot_rate: 0.1,
             pad_buttons: HashMap::from([
-                (GamepadButtonType::West, InputAction::Fire),      // X
+                (GamepadButtonType::West, InputAction::Fire), // X
+                (GamepadButtonType::RightTrigger2, InputAction::Fire),
+                (GamepadButtonType::LeftTrigger2, InputAction::Fire),
                 (GamepadButtonType::South, InputAction::Interact), // A
                 (GamepadButtonType::DPadUp, InputAction::Forward),
                 (GamepadButtonType::DPadDown, InputAction::Backward),
                 (GamepadButtonType::DPadLeft, InputAction::Left),
                 (GamepadButtonType::DPadRight, InputAction::Right),
-                (GamepadButtonType::Select, InputAction::Pause),
+                (GamepadButtonType::Start, InputAction::Pause),
             ]),
             pad_rot_x: GamepadAxisType::RightStickX,
             pad_rot_y: GamepadAxisType::RightStickY,
@@ -207,7 +209,7 @@ pub fn get_player_input(
 
         // TODO: Configurable sticks
         if let Some(dx) = pad_axes.get(axis(gamepad, key_map.pad_rot_x)) {
-            state.pitch += dx * time.delta_seconds();
+            state.yaw -= dx * time.delta_seconds(); //+= results in inverted rotation
         }
         if let Some(dy) = pad_axes.get(axis(gamepad, key_map.pad_rot_y)) {
             state.pitch += dy * time.delta_seconds();
@@ -215,7 +217,7 @@ pub fn get_player_input(
 
         if let Some(dx) = pad_axes.get(axis(gamepad, key_map.pad_move_x)) {
             if let Some(dy) = pad_axes.get(axis(gamepad, key_map.pad_move_y)) {
-                acts.send(InputAction::Move(dx, dy));
+                acts.send(InputAction::Move(dy, dx)); //y coresponds to forward back, x to left right
             }
         }
 


### PR DESCRIPTION
Fixes the following -
- Movement using left stick works as intended
- Camera movement using right stick now works for left and right too
- X, Left Trigger and Right Trigger can be used to fire
- Start pauses, instead of select